### PR TITLE
fix: workflow runs on error

### DIFF
--- a/workflows.tf
+++ b/workflows.tf
@@ -1,13 +1,12 @@
-# workflows.tf
-# Adding the param_bindings attribute to the trigger condition.
-
+# This defines a workflow for Release Engineering incidents.
+# Workflows automate actions based on incident triggers and conditions.
 resource "incident_workflow" "releng_default_workflow" {
   name = "Release Engineering Default Workflow"
 
-  # Required arguments with default values.
+  # Required arguments for the workflow's basic behavior.
   state                     = "active"
   include_private_incidents = true
-  runs_on_incidents         = true
+  runs_on_incidents         = "newly_created"
   trigger                   = "incident.created"
   continue_on_step_error    = false
   runs_on_incident_modes    = []
@@ -15,7 +14,7 @@ resource "incident_workflow" "releng_default_workflow" {
   expressions               = []
   steps                     = []
 
-  # This block now contains the logic to filter for our specific alert source.
+  # Filter which incidents this workflow applies to
   condition_groups = [
     {
       conditions = [
@@ -23,7 +22,7 @@ resource "incident_workflow" "releng_default_workflow" {
           subject        = "incident.alert_source_id"
           operation      = "is_one_of"
           value          = [incident_alert_source.releng.id]
-          param_bindings = [] # Adding the required empty attribute
+          param_bindings = []
         }
       ]
     }


### PR DESCRIPTION
Corrected invalid 'runs_on_incidents' value in the default workflow. Changed from 'true' to 'newly_created' to align with API requirements, allowing workflow creation.